### PR TITLE
feat: Adding version-file-path input for release

### DIFF
--- a/workflow-templates/python-release-org.yml
+++ b/workflow-templates/python-release-org.yml
@@ -68,3 +68,4 @@ jobs:
         major-release: ${{ inputs.major-release }}
         pypi-username: ${{ secrets.PYPI_USERNAME }}
         pypi-password: ${{ secrets.PYPI_PASSWORD }}
+        version-file-path: --- ADD PATH HERE ---


### PR DESCRIPTION
To accommodate different possible places repos could store the version number.